### PR TITLE
12 extracting aws cli to directories other than source code directory

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,35 @@ jobs:
           target_workflow_name: "test-action.yml"
           gh_token: ${{ secrets.GH_TOKEN }} # scope: repo + workflow
 
+  test_dirs:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - TEST_NAME: "ROOTDIR v2"
+            AWS_CLI_VERSION: "2"
+            ROOTDIR: "/tmp"
+          - TEST_NAME: "WORKDIR v2"
+            AWS_CLI_VERSION: "2"
+            WORKDIR: "/tmp/unfor19-awscli"            
+          - TEST_NAME: "ROOTDIR v1"
+            AWS_CLI_VERSION: "1"
+            ROOTDIR: "/tmp"
+          - TEST_NAME: "WORKDIR v1"
+            AWS_CLI_VERSION: "1"
+            WORKDIR: "/tmp/unfor19-awscli" 
+    name: Test ${{ matrix.TEST_NAME }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test On Runner
+        env:
+          AWS_CLI_VERSION: "${{ matrix.AWS_CLI_VERSION}}"
+          AWS_CLI_ARCH: "${{ matrix.AWS_CLI_ARCH }}"
+          ROOTDIR: "${{ matrix.ROOTDIR }}" 
+          WORKDIR: "${{ matrix.WORKDIR }}"
+        run: |
+          sudo ./entrypoint.sh
+
   test_amd64:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
           ROOTDIR: "${{ matrix.ROOTDIR }}" 
           WORKDIR: "${{ matrix.WORKDIR }}"
         run: |
-          sudo ./entrypoint.sh
+          sudo --preserve-env ./entrypoint.sh
 
   test_amd64:
     runs-on: ubuntu-20.04
@@ -74,7 +74,7 @@ jobs:
           AWS_CLI_VERSION: "${{ matrix.AWS_CLI_VERSION}}"
           AWS_CLI_ARCH: "${{ matrix.AWS_CLI_ARCH }}"
         run: |
-          sudo ./entrypoint.sh
+          sudo --preserve-env ./entrypoint.sh
 
   test_arm64:
     # Supports only v2+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -202,7 +202,7 @@ test_lightsailctl(){
 ### Global Variables
 msg_log "Provided ROOTDIR: ${ROOT_DIR}"
 _ROOT_DIR="${ROOT_DIR:-$PWD}"
-msg_log "Provided WORKDIR: ${ROOT_DIR}"
+msg_log "Provided WORKDIR: ${WORKDIR}"
 _WORKDIR="${WORKDIR:-${_ROOT_DIR}/unfor19-awscli}"
 msg_log "Final WORKDIR path: ${_WORKDIR}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -200,8 +200,8 @@ test_lightsailctl(){
 
 
 ### Global Variables
-_ROOT_DIR="${PWD}"
-_WORKDIR="${_ROOT_DIR}/unfor19-awscli"
+_ROOT_DIR="${ROOT_DIR:-$PWD}"
+_WORKDIR="${WORKDIR:-${_ROOT_DIR}/unfor19-awscli}"
 _DOWNLOAD_FILENAME="unfor19-awscli.zip"
 _VERBOSE=${VERBOSE:-"false"}
 _LIGHTSAIL_INSTALL=${LIGHTSAILCTL:-"false"}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -200,8 +200,12 @@ test_lightsailctl(){
 
 
 ### Global Variables
+msg_log "Provided ROOTDIR: ${ROOT_DIR}"
 _ROOT_DIR="${ROOT_DIR:-$PWD}"
+msg_log "Provided WORKDIR: ${ROOT_DIR}"
 _WORKDIR="${WORKDIR:-${_ROOT_DIR}/unfor19-awscli}"
+msg_log "Final WORKDIR path: ${_WORKDIR}"
+
 _DOWNLOAD_FILENAME="unfor19-awscli.zip"
 _VERBOSE=${VERBOSE:-"false"}
 _LIGHTSAIL_INSTALL=${LIGHTSAILCTL:-"false"}


### PR DESCRIPTION
Closes #12 

- Added environment variables: 
  - `ROOTDIR` - defaults to `$PWD`
  - `WORKDIR` - defaults to `${ROOTDIR}/unfor19-awscli`
- CI/CD
  - Made sure that v1 is tested
  - Added `-E` flag to `sudo` in tests to pass all environment variables