### PR TITLE
Updating to remove set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,5 +49,5 @@ runs:
       run: sudo --preserve-env ${{ github.action_path }}/entrypoint.sh
       shell: bash
     - id: set-output
-      run: echo "::set-output name=version::$(aws --version)"
+      run: echo "version=$(aws --version)" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
Per [Github](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) set-output is now deprecated and should be removed.