### PR TITLE
fallback to curl if wget is not installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !.*ignore*
 !.github
 *.zip
+unfor19-awscli/


### PR DESCRIPTION
- Sets download tool to `wget` by default and fallback to `curl`; if none is available, will fail in the beginning.
- Improved the error message in the "Provided version does not exist" - prints the error message in case of a failure
- Fixes issue #20 where only `curl` is available and `wget` is not.