### PR TITLE
Replace `github.action_path` into `GITHUB_ACTION_PATH`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
         echo "WORKDIR=${{ inputs.workdir }}" >> $GITHUB_ENV
       shell: bash
     - id: install-aws-cli
-      run: sudo --preserve-env ${{ github.action_path }}/entrypoint.sh
+      run: sudo --preserve-env ${GITHUB_ACTION_PATH}/entrypoint.sh
       shell: bash
     - id: set-output
       run: echo "version=$(aws --version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Due to the bug of GitHub Action Runner (actions/runner#716), `github.action_path` context value is not evaluated into valid path in containers on self-hosted runners. The corresponding environment variable `GITHUB_ACTION_PATH` always contains valid path even actions running on self-hosted runners, so this PR replaces `github.action_path` context into `GITHUB_ACTION_PATH` environment variable.