### PR TITLE
added bindir and installdir as arguments

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,12 @@ jobs:
           - TEST_NAME: "WORKDIR v1"
             AWS_CLI_VERSION: "1"
             WORKDIR: "/tmp/unfor19-awscli" 
+          - TEST_NAME: "BINDIR v2"
+            AWS_CLI_VERSION: "2"
+            BINDIR: "/tmp/aws/bin"
+          - TEST_NAME: "INSTALLROOTDIR v2"
+            AWS_CLI_VERSION: "2"
+            INSTALLROOTDIR: "/tmp/aws"  
     name: Test ${{ matrix.TEST_NAME }}
     steps:
       - uses: actions/checkout@v3
@@ -49,6 +55,8 @@ jobs:
           AWS_CLI_ARCH: "${{ matrix.AWS_CLI_ARCH }}"
           ROOTDIR: "${{ matrix.ROOTDIR }}" 
           WORKDIR: "${{ matrix.WORKDIR }}"
+          BINDIR: "${{ matrix.BINDIR }}"
+          INSTALLROOTDIR: "${{ matrix.INSTALLROOTDIR }}"
         run: |
           sudo --preserve-env ./entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -22,20 +22,35 @@ Valid AWS CLI `version` values:
 
 ### Usage
 
-Add the following step to a job in your workflow
+Add one of the following steps to a job in your workflow.
+
+#### Common Usage
 
 ```yaml
 - id: install-aws-cli
   uses: unfor19/install-aws-cli-action@v1
   with:
-    version: 2     # default
-    verbose: false # default
-    arch: amd64    # allowed values: amd64, arm64
-    rootdir: ""    # defaults to "PWD"
-    workdir: ""    # defaults to "PWD/unfor19-awscli"
+    version: 2                         # default
+    verbose: false                     # default
+    arch: amd64                        # allowed values: amd64, arm64
 ```
 
-### Full example
+#### Full Example
+
+```yaml
+- id: install-aws-cli
+  uses: unfor19/install-aws-cli-action@v1
+  with:
+    version: 2                         # default
+    verbose: false                     # default
+    arch: amd64                        # allowed values: amd64, arm64
+    bindir: "/usr/local/bin"           # default
+    installrootdir: "/usr/local"       # default
+    rootdir: ""                        # defaults to "PWD"
+    workdir: ""                        # defaults to "PWD/unfor19-awscli"
+```
+
+### Test with GitHub Matrix
 
 See [unfor19/install-aws-cli-action-test/blob/master/.github/workflows/test-action.yml](https://github.com/unfor19/install-aws-cli-action-test/blob/master/.github/workflows/test-action.yml)
 

--- a/action.yml
+++ b/action.yml
@@ -7,19 +7,27 @@ inputs:
   version:
     description: "1=latest version of v1, 2=latest version of v2, #.#.#=specific version"
     required: false
-    default: 2
+    default: "2"
   verbose:
     description: "Prints ls commands to see changes in the filesystem"
     required: false
-    default: false
+    default: "false"
   lightsailctl:
     description: "Install lightsailctl plugin"
     required: false
-    default: false
+    default: "false"
   arch:
     description: Allowed values are - amd64, arm64
     required: false
     default: amd64
+  bindir:
+    description: Bin directory full path, defaults to /usr/local/bin
+    required: false
+    default: /usr/local/bin
+  installrootdir:
+    description: Install directory full path, defaults to /usr/local
+    required: false
+    default: /usr/local
   rootdir:
     description: Root directory full path, defaults to PWD
     required: false
@@ -42,6 +50,8 @@ runs:
         echo "AWS_CLI_ARCH=${{ inputs.arch }}" >> $GITHUB_ENV        
         echo "VERBOSE=${{ inputs.verbose }}" >> $GITHUB_ENV
         echo "LIGHTSAILCTL=${{ inputs.lightsailctl }}" >> $GITHUB_ENV
+        echo "BINDIR=${{ inputs.bindir }}" >> $GITHUB_ENV
+        echo "INSTALLROOTDIR=${{ inputs.installrootdir }}" >> $GITHUB_ENV
         echo "ROOTDIR=${{ inputs.rootdir }}" >> $GITHUB_ENV
         echo "WORKDIR=${{ inputs.workdir }}" >> $GITHUB_ENV
       shell: bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -155,7 +155,7 @@ install_aws_cli(){
     wait
     msg_log "Installing AWS CLI - ${provided_version}"
     if [[ "$provided_version" =~ ^1.*$ ]]; then
-        ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+        ./awscli-bundle/install -i "${_INSTALLROOTDIR}}/aws" -b "${_BINDIR}/aws"
     elif [[ "$provided_version" =~ ^2.*$ ]]; then
         local aws_path=""
         aws_path=$(which aws || true)
@@ -164,10 +164,10 @@ install_aws_cli(){
             msg_error "Failed to install AWS CLI - Make sure AWS_CLI_ARCH is set properly, current value is ${provided_arch}"
         elif [[ "$aws_path" =~ ^.*aws.*not.*found || -z "$aws_path" ]]; then
             # Fresh install
-            ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli
+            ./aws/install --bin-dir "$_BINDIR" --install-dir "${_INSTALLROOTDIR}/aws-cli"
         else
             # Update
-            ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+            ./aws/install --bin-dir "$_BINDIR" --install-dir "${_INSTALLROOTDIR}/aws-cli" --update
         fi
     fi
     msg_log "Installation completed"
@@ -205,12 +205,12 @@ install_lightsailctl(){
     if [[ $provided_version =~ ^2.*$ ]]; then
         msg_log "Installing Lightsailctl"
         if [[ "$_AWS_CLI_DOWNLOAD_TOOL" = "wget" ]]; then
-            wget -q -O "/usr/local/bin/lightsailctl" "https://s3.us-west-2.amazonaws.com/lightsailctl/latest/linux-amd64/lightsailctl"
+            wget -q -O "${_BINDIR}/lightsailctl" "https://s3.us-west-2.amazonaws.com/lightsailctl/latest/linux-amd64/lightsailctl"
         elif [[ "$_AWS_CLI_DOWNLOAD_TOOL" = "curl" ]]; then
-            curl -sL -o "/usr/local/bin/lightsailctl"  "https://s3.us-west-2.amazonaws.com/lightsailctl/latest/linux-amd64/lightsailctl"
+            curl -sL -o "${_BINDIR}/lightsailctl"  "https://s3.us-west-2.amazonaws.com/lightsailctl/latest/linux-amd64/lightsailctl"
         fi
         wait
-        chmod +x /usr/local/bin/lightsailctl
+        chmod +x "${_BINDIR}/lightsailctl"
         msg_log "Installation complete"
     else
         msg_error "Cannot install Lightsail plugin with CLI 1.x"
@@ -230,6 +230,10 @@ test_lightsailctl(){
 
 
 ### Global Variables
+msg_log "Provided BINDIR: ${BINDIR}"
+_BINDIR="${BINDIR:-"/usr/local/bin"}"
+msg_log "Provided INSTALLROOTDIR: ${INSTALLROOTDIR}"
+_INSTALLROOTDIR="${INSTALLROOTDIR:-"/usr/local"}"
 msg_log "Provided ROOTDIR: ${ROOT_DIR}"
 _ROOT_DIR="${ROOT_DIR:-$PWD}"
 msg_log "Provided WORKDIR: ${WORKDIR}"


### PR DESCRIPTION
- Added two new inputs `bindir` and `installrootdir`, to allow consumers to use directories other than `/usr/local/bin` and `/usr/local`
- Updated docs example with "Common Usage" to reduce rarely used variables for newcomers
- Linted `action.yml` with strings instead of boolean true/false - to be aligned with GitHub Workflow schema

Closes #26