### PR TITLE
Don't call `sudo` when we're already root

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,12 @@ runs:
         echo "WORKDIR=${{ inputs.workdir }}" >> $GITHUB_ENV
       shell: bash
     - id: install-aws-cli
-      run: sudo --preserve-env ${GITHUB_ACTION_PATH}/entrypoint.sh
+      run: |
+        if [[ $UID == 0 ]]; then
+          "${GITHUB_ACTION_PATH}/entrypoint.sh"
+        else
+          sudo --preserve-env "${GITHUB_ACTION_PATH}/entrypoint.sh"
+        fi
       shell: bash
     - id: set-output
       run: echo "version=$(aws --version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
It's possible to execute actions inside a Docker container using (`container:`) - and it's possible (and I'd wager common) to already be root there and not have `sudo` available