### PR TITLE
Arch mappings for Github Runner Actions arch context

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add one of the following steps to a job in your workflow.
   with:
     version: 2                         # default
     verbose: false                     # default
-    arch: amd64                        # allowed values: amd64, x86, x64, arm, arm64
+    arch: amd64                        # allowed values: amd64, x86, x64, arm, arm64, X86, X64, ARM, ARM64
 ```
 
 #### Full Example
@@ -43,7 +43,7 @@ Add one of the following steps to a job in your workflow.
   with:
     version: 2                         # default
     verbose: false                     # default
-    arch: amd64                        # allowed values: amd64, arm64
+    arch: amd64                        # allowed values: amd64, x86, x64, arm, arm64, X86, X64, ARM, ARM64
     bindir: "/usr/local/bin"           # default
     installrootdir: "/usr/local"       # default
     rootdir: ""                        # defaults to "PWD"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,9 +70,9 @@ get_download_url(){
     # v2
     elif [[ "$provided_version" =~ ^2.*$ ]]; then
         # Check arch
-        if [[ "$provided_arch" =~ ^(amd64|x86|x64)$ ]]; then
+        if [[ "$provided_arch" =~ ^(amd64|x86|x64|X86|X64)$ ]]; then
             adjusted_arch="x86_64"
-        elif [[ "$provided_arch" =~ ^(arm64|arm)$ ]]; then
+        elif [[ "$provided_arch" =~ ^(arm64|arm|ARM|ARM64)$ ]]; then
             adjusted_arch="aarch64"
         else
             echo "Invalid arch - ${provided_arch}"


### PR DESCRIPTION
This allows you to map ${{ runner.arch }} directly into the arch field from the [runner context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context).